### PR TITLE
Component config extension

### DIFF
--- a/config/src/main/java/org/moskito/control/config/ComponentConfig.java
+++ b/config/src/main/java/org/moskito/control/config/ComponentConfig.java
@@ -1,9 +1,12 @@
 package org.moskito.control.config;
 
+import com.google.gson.Gson;
 import com.google.gson.annotations.SerializedName;
+import com.google.gson.reflect.TypeToken;
 import net.anotheria.util.StringUtils;
 import org.configureme.annotations.Configure;
 import org.configureme.annotations.ConfigureMe;
+import org.configureme.annotations.SetIf;
 
 import java.util.Arrays;
 import java.util.HashMap;
@@ -41,28 +44,9 @@ public class ComponentConfig {
     private ConnectorType connectorType;
 
     /**
-     * Type of method if component is a URL-connector.
-     * If component is non URL-connector, field is ignored.
+     * Map to store extra data specifically for component.
      */
-    @Configure
-    @SerializedName("methodType")
-    private HttpMethodType methodType;
-
-    /**
-     * Payload. If a provided method type above accepts payload (POST, PUT etc.)
-     */
-    @Configure
-    @SerializedName("payload")
-    private String payload;
-
-    /**
-     * Content type. Field is required if payload was provided.
-     * Only text-friendly content type.
-     * Example: application/json, application/xml.
-     */
-    @Configure
-    @SerializedName("contentType")
-    private String contentType;
+    private Map<String, String> data = new HashMap<>();
 
     /**
      * Headers map. Used with HttpUrlConnector.
@@ -116,30 +100,6 @@ public class ComponentConfig {
         this.connectorType = connectorType;
     }
 
-    public HttpMethodType getMethodType() {
-        return methodType;
-    }
-
-    public void setMethodType(HttpMethodType methodType) {
-        this.methodType = methodType;
-    }
-
-    public String getPayload() {
-        return payload;
-    }
-
-    public void setPayload(String payload) {
-        this.payload = payload;
-    }
-
-    public String getContentType() {
-        return contentType;
-    }
-
-    public void setContentType(String contentType) {
-        this.contentType = contentType;
-    }
-
     public HeaderParameter[] getHeaders() {
         return headers;
     }
@@ -172,15 +132,25 @@ public class ComponentConfig {
         this.tags = tags;
     }
 
+    public Map<String, String> getData() {
+        return data;
+    }
+
+    public void setData(Map<String, String> data) {
+        this.data = data;
+    }
+
+    @SetIf(condition = SetIf.SetIfCondition.matches, value = "data")
+    public void setMapData(String key, String value) {
+        this.data = new Gson().fromJson(value, new TypeToken<Map<String, String>>(){}.getType());
+    }
+
     @Override
     public String toString() {
         return "ComponentConfig{" +
                 "name='" + name + '\'' +
                 ", category='" + category + '\'' +
                 ", connectorType=" + connectorType +
-                ", methodType=" + methodType +
-                ", payload='" + payload + '\'' +
-                ", contentType='" + contentType + '\'' +
                 ", headers=" + Arrays.toString(headers) +
                 ", location='" + location + '\'' +
                 ", tags='" + tags + '\'' +

--- a/connectors/src/main/java/org/moskito/control/connectors/HttpURLConnector.java
+++ b/connectors/src/main/java/org/moskito/control/connectors/HttpURLConnector.java
@@ -13,11 +13,7 @@ import net.anotheria.moskito.core.predefined.ServiceStatsFactory;
 import net.anotheria.moskito.core.producers.CallExecution;
 import net.anotheria.moskito.core.producers.IStatsProducer;
 import net.anotheria.moskito.core.registry.ProducerRegistryFactory;
-import net.anotheria.moskito.core.threshold.Threshold;
-import net.anotheria.moskito.core.threshold.ThresholdConditionGuard;
-import net.anotheria.moskito.core.threshold.ThresholdRepository;
-import net.anotheria.moskito.core.threshold.ThresholdStatus;
-import net.anotheria.moskito.core.threshold.Thresholds;
+import net.anotheria.moskito.core.threshold.*;
 import net.anotheria.moskito.core.threshold.guard.DoubleBarrierPassGuard;
 import net.anotheria.moskito.core.threshold.guard.GuardedDirection;
 import net.anotheria.util.StringUtils;
@@ -28,28 +24,22 @@ import org.apache.http.auth.UsernamePasswordCredentials;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.entity.ContentType;
 import org.apache.http.message.BasicHeader;
+import org.moskito.control.common.AccumulatorDataItem;
+import org.moskito.control.common.HealthColor;
+import org.moskito.control.common.Status;
+import org.moskito.control.common.ThresholdDataItem;
 import org.moskito.control.config.ComponentConfig;
 import org.moskito.control.config.HeaderParameter;
 import org.moskito.control.config.HttpMethodType;
 import org.moskito.control.connectors.httputils.HttpHelper;
 import org.moskito.control.connectors.parsers.ParserHelper;
-import org.moskito.control.connectors.response.ConnectorAccumulatorResponse;
-import org.moskito.control.connectors.response.ConnectorAccumulatorsNamesResponse;
-import org.moskito.control.connectors.response.ConnectorInformationResponse;
-import org.moskito.control.connectors.response.ConnectorStatusResponse;
-import org.moskito.control.connectors.response.ConnectorThresholdsResponse;
-import org.moskito.control.common.HealthColor;
-import org.moskito.control.common.AccumulatorDataItem;
-import org.moskito.control.common.Status;
-import org.moskito.control.common.ThresholdDataItem;
+import org.moskito.control.connectors.response.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.LinkedList;
 import java.util.List;
-import java.util.Map;
 
 /**
  * Generic Http URL connector.
@@ -101,16 +91,18 @@ public class HttpURLConnector extends AbstractConnector {
     private static Header gzipHeader = new BasicHeader(HttpHeaders.ACCEPT_ENCODING, "gzip");
 
     @Override
-    public void configure(ComponentConfig config){
+    public void configure(ComponentConfig config) {
         this.componentName = config.getName();
         this.location = config.getLocation();
         this.credentials = ParserHelper.getCredentials(config.getCredentials());
-        this.methodType = config.getMethodType();
-        this.payload = config.getPayload();
-        this.contentType = config.getContentType();
+
+        String method = config.getData().get("methodType");
+        this.methodType = method == null ? null : HttpMethodType.valueOf(method);
+        this.payload = config.getData().get("payload");
+        this.contentType = config.getData().get("contentType");
         HeaderParameter[] headers = config.getHeaders();
 
-        if(headers != null) {
+        if (headers != null) {
             this.headers = new Header[headers.length + 1];
             for (int i = 0; i < headers.length; i++) {
                 this.headers[i] = new BasicHeader(headers[i].getKey(), headers[i].getValue());

--- a/connectors/src/test/java/org/moskito/control/connectors/HttpURLConnectorTest.java
+++ b/connectors/src/test/java/org/moskito/control/connectors/HttpURLConnectorTest.java
@@ -20,10 +20,9 @@ import org.apache.http.protocol.HttpRequestExecutor;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
-import org.moskito.control.config.ComponentConfig;
-import org.moskito.control.config.HttpMethodType;
-import org.moskito.control.connectors.httputils.HttpHelper;
 import org.moskito.control.common.HealthColor;
+import org.moskito.control.config.ComponentConfig;
+import org.moskito.control.connectors.httputils.HttpHelper;
 
 import java.io.IOException;
 import java.io.OutputStream;
@@ -73,7 +72,7 @@ public class HttpURLConnectorTest {
         ComponentConfig ret = new ComponentConfig();
         ret.setName("testName");
         ret.setLocation(location);
-        ret.setMethodType(HttpMethodType.GET);
+        ret.getData().put("methodType", "GET");
         return ret;
     }
 

--- a/ui/src/main/java/org/moskito/control/ui/action/inspection/ShowComponentInformationAction.java
+++ b/ui/src/main/java/org/moskito/control/ui/action/inspection/ShowComponentInformationAction.java
@@ -49,16 +49,22 @@ public class ShowComponentInformationAction extends BaseMoSKitoControlAction {
         info.put("Update type", component.isDynamic() ? "push" : "pull");
 
         if (component.getConfiguration().getConnectorType() == ConnectorType.URL) {
-            HttpMethodType methodType = component.getConfiguration().getMethodType();
+            String method = component.getConfiguration().getData().get("methodType");
+            HttpMethodType methodType = method == null ? null : HttpMethodType.valueOf(method);
             if (methodType != null) {
                 info.put("Method Type", methodType.name());
             }
-            if (component.getConfiguration().getPayload() != null) {
-                info.put("Payload", formatPayload(component.getConfiguration().getPayload()));
+
+            String payload = component.getConfiguration().getData().get("payload");
+            if (payload != null) {
+                info.put("Payload", formatPayload(payload));
             }
-            if (component.getConfiguration().getContentType() != null) {
-                info.put("Content-Type", component.getConfiguration().getContentType());
+
+            String contentType = component.getConfiguration().getData().get("contentType");
+            if (contentType != null) {
+                info.put("Content-Type", contentType);
             }
+
             if (component.getConfiguration().getHeaders() != null) {
                 info.put("Headers", formatHeaders(component.getConfiguration().getHeaders()));
             }


### PR DESCRIPTION
Component config now doesn't contain HTTP-Connector-related fields. Now it has a data map where stored per-component data.